### PR TITLE
keepMessage

### DIFF
--- a/src/main/java/me/fallenbreath/tweakermore/config/TweakerMoreConfigs.java
+++ b/src/main/java/me/fallenbreath/tweakermore/config/TweakerMoreConfigs.java
@@ -753,6 +753,12 @@ public class TweakerMoreConfigs
 
 	@Config(
 			type = Config.Type.GENERIC,
+			restriction = @Restriction(require = @Condition(value = minecraft, versionPredicates = ">=1.20.4")),
+			category = Config.Category.PORTING
+	)
+	public static final TweakerMoreConfigBoolean KEEP_MESSAGE = newConfigBoolean("keepMessage", false);
+	@Config(
+			type = Config.Type.GENERIC,
 			restriction = @Restriction(require = {
 					@Condition(litematica),
 					@Condition(value = minecraft, versionPredicates = "<1.17")

--- a/src/main/java/me/fallenbreath/tweakermore/mixins/tweaks/porting/keepMessage/MinecraftClientMixin.java
+++ b/src/main/java/me/fallenbreath/tweakermore/mixins/tweaks/porting/keepMessage/MinecraftClientMixin.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the TweakerMore project, licensed under the
+ * GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2024  Fallen_Breath and contributors
+ *
+ * TweakerMore is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TweakerMore is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with TweakerMore.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.fallenbreath.tweakermore.mixins.tweaks.porting.keepMessage;
+
+import me.fallenbreath.conditionalmixin.api.annotation.Condition;
+import me.fallenbreath.conditionalmixin.api.annotation.Restriction;
+import me.fallenbreath.tweakermore.util.ModIds;
+import me.fallenbreath.tweakermore.util.mixin.DummyClass;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Restriction(require = @Condition(value = ModIds.minecraft, versionPredicates = ">=1.20.2"))
+@Mixin(DummyClass.class)
+public abstract class MinecraftClientMixin
+{
+}

--- a/src/main/resources/assets/tweakermore/lang/en_us.yml
+++ b/src/main/resources/assets/tweakermore/lang/en_us.yml
@@ -835,6 +835,11 @@ tweakermore:
       comment: |-
         Fixed SCROLL_STACKS_FALLBACK of item-scroller ignores the last stack
         The same as masa's fixed in itemscoller commit 0984fe7
+    keepMessage:
+      .: keepMessage
+      comment: |-
+        Keep your chat messages
+        With this option, When you use "/server", the client retains your chat message
     lmCustomSchematicBaseDirectoryEnabledPorting:
       .: lmCustomSchematicBaseDirectoryEnabledPorting
       comment: Backport option customSchematicBaseDirectoryEnabled from Litematica 0.9.0 mc1.17+

--- a/src/main/resources/assets/tweakermore/lang/zh_cn.yml
+++ b/src/main/resources/assets/tweakermore/lang/zh_cn.yml
@@ -835,6 +835,11 @@ tweakermore:
       comment: |-
         修复ItemScroller的SCROLL_STACKS_FALLBACK未考虑最后一组物品
         同masa在itemscroller的修复commit 0984fe7相同
+    keepMessage:
+      .: 保留聊天信息
+      comment: |-
+        保留你的聊天信息
+        借此, 当你使用"/server"切换服务器时, 客户端会保留你的聊天信息
     lmCustomSchematicBaseDirectoryEnabledPorting:
       .: Litematica自定义原理图根文件夹开关-移植
       comment: 从Litematica 0.9.0 mc1.17+移植customSchematicBaseDirectoryEnabled

--- a/src/main/resources/tweakermore.mixins.json
+++ b/src/main/resources/tweakermore.mixins.json
@@ -188,6 +188,7 @@
     "tweaks.mod_tweaks.xmapNoSessionFinalizationWait.WorldMapSessionMixin",
     "tweaks.mod_tweaks.xmapWaypointFreecamCompact.WorldMapSessionMixin",
     "tweaks.porting.isScrollStacksFallbackFixPorting.InventoryUtilsMixin",
+    "tweaks.porting.keepMessage.MinecraftClientMixin",
     "tweaks.porting.lmCustomSchematicBaseDirectoryPorting.DataManagerMixin",
     "tweaks.porting.lmPickBlockShulkersPorting.WorldUtilsMixin",
     "tweaks.porting.mcSpectatorEnterSinkingFixPorting.ClientPlayNetworkHandlerMixin",

--- a/versions/1.20.2/src/main/java/me/fallenbreath/tweakermore/mixins/tweaks/porting/keepMessage/MinecraftClientMixin.java
+++ b/versions/1.20.2/src/main/java/me/fallenbreath/tweakermore/mixins/tweaks/porting/keepMessage/MinecraftClientMixin.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the TweakerMore project, licensed under the
+ * GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2024  Fallen_Breath and contributors
+ *
+ * TweakerMore is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TweakerMore is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with TweakerMore.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.fallenbreath.tweakermore.mixins.tweaks.porting.keepMessage;
+
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import me.fallenbreath.conditionalmixin.api.annotation.Condition;
+import me.fallenbreath.conditionalmixin.api.annotation.Restriction;
+import me.fallenbreath.tweakermore.config.TweakerMoreConfigs;
+import me.fallenbreath.tweakermore.util.ModIds;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.hud.InGameHud;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Restriction(require = @Condition(value = ModIds.minecraft, versionPredicates = ">=1.20.2"))
+@Mixin(MinecraftClient.class)
+public abstract class MinecraftClientMixin
+{
+    @WrapWithCondition(
+            method = "enterReconfiguration",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/InGameHud;clear()V")
+    )
+    private boolean keepMessage(InGameHud instance)
+    {
+        return !TweakerMoreConfigs.KEEP_MESSAGE.getBooleanValue();
+    }
+}


### PR DESCRIPTION
#57 

- 不依赖fabric-api
- 依赖minecraft >= 1.20.2

玩家使用```/server```切换服务器时会进入配置阶段, 这个阶段会清除聊天记录

使用```@WrapWithCondition```将清除聊天记录代码包裹上```if```, 问题就解决了

玩家disconnect的时候, 记录会正常清除

# 其他

于1.20.4测试正常