### PR TITLE
update 1.21 masa's mod dependency, fix crashing due to tweakeroo changes

### DIFF
--- a/src/main/java/me/fallenbreath/tweakermore/mixins/tweaks/features/schematicProPlace/PlacementTweaksMixin.java
+++ b/src/main/java/me/fallenbreath/tweakermore/mixins/tweaks/features/schematicProPlace/PlacementTweaksMixin.java
@@ -30,6 +30,7 @@ import me.fallenbreath.conditionalmixin.api.annotation.Restriction;
 import me.fallenbreath.tweakermore.impl.features.schematicProPlace.ProPlaceImpl;
 import me.fallenbreath.tweakermore.util.BlockUtil;
 import me.fallenbreath.tweakermore.util.ModIds;
+import me.fallenbreath.tweakermore.util.compat.tweakermore.TweakerooAccess;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.network.ClientPlayerInteractionManager;
@@ -132,7 +133,7 @@ public abstract class PlacementTweaksMixin
 		// Carpet-Extra mod accurate block placement protocol support
 		if (flexible && rotation && accurate == false &&
 				//#if MC >= 12100
-				//$$ Configs.Generic.ACCURATE_PLACEMENT_PROTOCOL.getBooleanValue() &&
+				//$$ TweakerooAccess.getAccuratePlacementProtocolValue() &&
 				//#elseif MC >= 11700
 				//$$ Configs.Generic.CARPET_ACCURATE_PLACEMENT_PROTOCOL.getBooleanValue() &&
 				//#else

--- a/src/main/java/me/fallenbreath/tweakermore/mixins/tweaks/features/schematicProPlace/PlacementTweaksMixin.java
+++ b/src/main/java/me/fallenbreath/tweakermore/mixins/tweaks/features/schematicProPlace/PlacementTweaksMixin.java
@@ -131,7 +131,9 @@ public abstract class PlacementTweaksMixin
 
 		// Carpet-Extra mod accurate block placement protocol support
 		if (flexible && rotation && accurate == false &&
-				//#if MC >= 11700
+				//#if MC >= 12100
+				//$$ Configs.Generic.ACCURATE_PLACEMENT_PROTOCOL.getBooleanValue() &&
+				//#elseif MC >= 11700
 				//$$ Configs.Generic.CARPET_ACCURATE_PLACEMENT_PROTOCOL.getBooleanValue() &&
 				//#else
 				FeatureToggle.CARPET_ACCURATE_PLACEMENT_PROTOCOL.getBooleanValue() &&

--- a/src/main/java/me/fallenbreath/tweakermore/util/compat/tweakermore/TweakerooAccess.java
+++ b/src/main/java/me/fallenbreath/tweakermore/util/compat/tweakermore/TweakerooAccess.java
@@ -20,7 +20,10 @@
 
 package me.fallenbreath.tweakermore.util.compat.tweakermore;
 
+import fi.dy.masa.malilib.config.options.ConfigBoolean;
+import fi.dy.masa.tweakeroo.config.Configs;
 import fi.dy.masa.tweakeroo.util.CameraEntity;
+import me.fallenbreath.tweakermore.util.ReflectionUtil;
 import net.minecraft.client.network.ClientPlayerEntity;
 import org.jetbrains.annotations.Nullable;
 
@@ -30,5 +33,24 @@ public class TweakerooAccess
 	public static ClientPlayerEntity getFreecamEntity()
 	{
 		return CameraEntity.getCamera();
+	}
+
+	// for 1.21+ tweakeroo,
+	// CARPET_ACCURATE_PLACEMENT_PROTOCOL changed to ACCURATE_PLACEMENT_PROTOCOL
+	public static boolean getAccuratePlacementProtocolValue()
+	{
+		Class<?> genericClass = Configs.Generic.class;
+		ReflectionUtil.ValueWrapper<ConfigBoolean> newAccField = ReflectionUtil.getStaticField(genericClass, "ACCURATE_PLACEMENT_PROTOCOL");
+		if (newAccField.isPresent())
+		{
+			return newAccField.get().getBooleanValue();
+		}
+		ReflectionUtil.ValueWrapper<ConfigBoolean> oldAccField = ReflectionUtil.getStaticField(genericClass, "CARPET_ACCURATE_PLACEMENT_PROTOCOL");
+		if (oldAccField.isPresent())
+		{
+			return oldAccField.get().getBooleanValue();
+		}
+
+		return false;
 	}
 }

--- a/versions/1.21/gradle.properties
+++ b/versions/1.21/gradle.properties
@@ -16,19 +16,19 @@
 
 	# https://masa.dy.fi/maven/fi/dy/masa/malilib/
 	# https://jitpack.io/#sakura-ryoko/malilib
-	malilib_version = 1.21-sakura.7
+	malilib_version = 1.21-sakura.2
 
 	# https://legacy.curseforge.com/minecraft/mc-mods/tweakeroo/files
 	# https://jitpack.io/#sakura-ryoko/tweakeroo
-	tweakeroo_file_id = 1.21-sakura.16
+	tweakeroo_file_id = 1.21-sakura.3
 
 	# https://legacy.curseforge.com/minecraft/mc-mods/item-scroller/files
 	# https://jitpack.io/#sakura-ryoko/itemscroller
-	itemscroller_file_id = 1.21-sakura.4
+	itemscroller_file_id = 1.21-sakura.1
 
 	# https://legacy.curseforge.com/minecraft/mc-mods/litematica/files
 	# https://jitpack.io/#sakura-ryoko/litematica
-	litematica_file_id = 1.21-sakura.19
+	litematica_file_id = 1.21-sakura.4
 
 	# https://legacy.curseforge.com/minecraft/mc-mods/minihud/files
 	# https://jitpack.io/#sakura-ryoko/minihud

--- a/versions/1.21/gradle.properties
+++ b/versions/1.21/gradle.properties
@@ -16,19 +16,19 @@
 
 	# https://masa.dy.fi/maven/fi/dy/masa/malilib/
 	# https://jitpack.io/#sakura-ryoko/malilib
-	malilib_version = 1.21-sakura.2
+	malilib_version = 1.21-sakura.7
 
 	# https://legacy.curseforge.com/minecraft/mc-mods/tweakeroo/files
 	# https://jitpack.io/#sakura-ryoko/tweakeroo
-	tweakeroo_file_id = 1.21-sakura.3
+	tweakeroo_file_id = 1.21-sakura.16
 
 	# https://legacy.curseforge.com/minecraft/mc-mods/item-scroller/files
 	# https://jitpack.io/#sakura-ryoko/itemscroller
-	itemscroller_file_id = 1.21-sakura.1
+	itemscroller_file_id = 1.21-sakura.4
 
 	# https://legacy.curseforge.com/minecraft/mc-mods/litematica/files
 	# https://jitpack.io/#sakura-ryoko/litematica
-	litematica_file_id = 1.21-sakura.4
+	litematica_file_id = 1.21-sakura.19
 
 	# https://legacy.curseforge.com/minecraft/mc-mods/minihud/files
 	# https://jitpack.io/#sakura-ryoko/minihud


### PR DESCRIPTION
In this [commit](https://github.com/sakura-ryoko/tweakeroo/commit/36a640f2c6f6cc0f3ec1073a4ebc92b02b72ffc0#diff-196b9bde7dd7a559e5fa5439e304e1d279bc7b256fd0da9c7dc3b91fd37f0507L47) of tweakeroo, `CARPET_ACCURATE_PLACEMENT_PROTOCOL` changed to `ACCURATE_PLACEMENT_PROTOCOL`, which will cause game to crash when using accurate block placement while having pro place feature enabled.
