### PR TITLE
Fix java.lang.NullPointerException for APPLY_TWEAKER_MORE_OPTION_LABEL_GLOBALLY

### DIFF
--- a/src/main/java/me/fallenbreath/tweakermore/mixins/core/gui/panel/labelWithOriginalText/WidgetListConfigOptionMixin.java
+++ b/src/main/java/me/fallenbreath/tweakermore/mixins/core/gui/panel/labelWithOriginalText/WidgetListConfigOptionMixin.java
@@ -76,7 +76,7 @@ public abstract class WidgetListConfigOptionMixin extends WidgetConfigOptionBase
 			int height = args.get(3);
 			int textColor = args.get(4);
 			String[] lines = args.get(5);
-			if (lines.length != 1)
+			if (lines != null && lines.length != 1)
 			{
 				return;
 			}

--- a/src/main/java/me/fallenbreath/tweakermore/mixins/core/gui/panel/labelWithOriginalText/WidgetListConfigOptionMixin.java
+++ b/src/main/java/me/fallenbreath/tweakermore/mixins/core/gui/panel/labelWithOriginalText/WidgetListConfigOptionMixin.java
@@ -76,7 +76,7 @@ public abstract class WidgetListConfigOptionMixin extends WidgetConfigOptionBase
 			int height = args.get(3);
 			int textColor = args.get(4);
 			String[] lines = args.get(5);
-			if (lines != null && lines.length != 1)
+			if (lines == null && lines.length != 1)
 			{
 				return;
 			}

--- a/src/main/java/me/fallenbreath/tweakermore/mixins/core/gui/panel/labelWithOriginalText/WidgetListConfigOptionMixin.java
+++ b/src/main/java/me/fallenbreath/tweakermore/mixins/core/gui/panel/labelWithOriginalText/WidgetListConfigOptionMixin.java
@@ -76,7 +76,7 @@ public abstract class WidgetListConfigOptionMixin extends WidgetConfigOptionBase
 			int height = args.get(3);
 			int textColor = args.get(4);
 			String[] lines = args.get(5);
-			if (lines == null && lines.length != 1)
+			if (lines == null || lines.length != 1)
 			{
 				return;
 			}


### PR DESCRIPTION
(not tested yet since it's still building on my poor pc. i'll close this if it's not fixed then)

Fix conflict with Pairman/Lithonate caused by APPLY_TWEAKER_MORE_OPTION_LABEL_GLOBALLY, every time opening the config menu.

```
java.lang.NullPointerException: Cannot read the array length because "lines" is null
	at knot//fi.dy.masa.malilib.gui.widgets.WidgetConfigOption.args$fkb000$tweakermore$useMyBetterOptionLabelForTweakerMore(WidgetConfigOption.java:4579)
	at knot//fi.dy.masa.malilib.gui.widgets.WidgetConfigOption.addConfigOption(WidgetConfigOption.java:106)
	at knot//fi.dy.masa.malilib.gui.widgets.WidgetConfigOption.<init>(WidgetConfigOption.java:87)
	at knot//fi.dy.masa.malilib.gui.widgets.WidgetListConfigOptions.createListEntryWidget(WidgetListConfigOptions.java:103)
	at knot//fi.dy.masa.malilib.gui.widgets.WidgetListConfigOptions.createListEntryWidget(WidgetListConfigOptions.java:18)
	at knot//fi.dy.masa.malilib.gui.widgets.WidgetListBase.createListEntryWidgetIfSpace(WidgetListBase.java:513)
	at knot//fi.dy.masa.malilib.gui.widgets.WidgetListBase.reCreateListEntryWidgets(WidgetListBase.java:485)
	at knot//fi.dy.masa.malilib.gui.widgets.WidgetListConfigOptionsBase.reCreateListEntryWidgets(WidgetListConfigOptionsBase.java:39)
	at knot//fi.dy.masa.malilib.gui.widgets.WidgetListConfigOptions.reCreateListEntryWidgets(WidgetListConfigOptions.java:53)
	at knot//fi.dy.masa.malilib.gui.widgets.WidgetListBase.refreshBrowserEntries(WidgetListBase.java:297)
	at knot//fi.dy.masa.malilib.gui.widgets.WidgetListBase.refreshEntries(WidgetListBase.java:534)
	at knot//fi.dy.masa.malilib.gui.widgets.WidgetListBase.initGui(WidgetListBase.java:71)
	at knot//fi.dy.masa.malilib.gui.GuiListBase.initGui(GuiListBase.java:74)
	at knot//fi.dy.masa.malilib.gui.GuiConfigsBase.initGui(GuiConfigsBase.java:119)
	at knot//org.eu.pnxlr.lithonate.gui.LithonateConfigGui.initGui(LithonateConfigGui.java:67)
	at knot//fi.dy.masa.malilib.gui.GuiBase.init(GuiBase.java:133)
	at knot//net.minecraft.client.gui.screen.Screen.init(Screen.java:325)
	at knot//fi.dy.masa.malilib.gui.GuiListBase.init(GuiListBase.java:165)
	at knot//net.minecraft.client.MinecraftClient.openScreen(MinecraftClient.java:922)
	at knot//fi.dy.masa.malilib.gui.GuiBase.openGui(GuiBase.java:619)
	at knot//fi.dy.masa.malilib.gui.GuiConfigsBase.md0f2683$masa_gadget_mod-1_16_5$lambda$postInitGui$0$4(GuiConfigsBase.java:1052)
	at knot//com.plusls.MasaGadget.gui.MyWidgetDropDownList.setSelectedEntry(MyWidgetDropDownList.java:33)
	at knot//fi.dy.masa.malilib.gui.widgets.WidgetDropDownList.onMouseClickedImpl(WidgetDropDownList.java:138)
	at knot//fi.dy.masa.malilib.gui.widgets.WidgetBase.onMouseClicked(WidgetBase.java:92)
	at knot//fi.dy.masa.malilib.gui.GuiBase.onMouseClicked(GuiBase.java:262)
	at knot//fi.dy.masa.malilib.gui.GuiListBase.onMouseClicked(GuiListBase.java:92)
	at knot//fi.dy.masa.malilib.gui.GuiConfigsBase.onMouseClicked(GuiConfigsBase.java:192)
	at knot//fi.dy.masa.malilib.gui.GuiBase.mouseClicked(GuiBase.java:185)
	at knot//net.minecraft.client.Mouse.method_1611(Mouse.java:92)
	at knot//net.minecraft.client.gui.screen.Screen.wrapScreenError(Screen.java:435)
	at knot//net.minecraft.client.Mouse.onMouseButton(Mouse.java:92)
	at knot//net.minecraft.client.Mouse.method_22686(Mouse.java:162)
	at knot//net.minecraft.loot.function.LootingEnchantLootFunction5.execute(ThreadExecutor.java:94)
	at knot//net.minecraft.client.Mouse.method_22684(Mouse.java:162)
	at knot//org.lwjgl.glfw.GLFWMouseButtonCallback$Container.invoke(GLFWMouseButtonCallback.java:81)
	at knot//bre2el.fpsreducer.handler.glfw.InputEventHandler$MouseButtonEventHandler.invoke(InputEventHandler.java:133)
	at knot//org.lwjgl.glfw.GLFWMouseButtonCallbackI.callback(GLFWMouseButtonCallbackI.java:36)
	at knot//org.lwjgl.system.JNI.invokeV(Native Method)
	at knot//org.lwjgl.glfw.GLFW.glfwPollEvents(GLFW.java:3101)
	at knot//com.mojang.blaze3d.systems.RenderSystem.flipFrame(RenderSystem.java:109)
	at knot//net.minecraft.client.util.Window.swapBuffers(Window.java:308)
	at knot//net.minecraft.client.MinecraftClient.render(MinecraftClient.java:1068)
	at knot//net.minecraft.client.MinecraftClient.run(MinecraftClient.java:681)
	at knot//net.minecraft.client.main.Main.main(Main.java:215)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:480)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at oolloo.jlw.Wrapper.invokeMain(Wrapper.java:112)
	at oolloo.jlw.Wrapper.main(Wrapper.java:105)
```