### PR TITLE
add tadpoleBucketGrowthLeftTime

### DIFF
--- a/docs/document-en_us.md
+++ b/docs/document-en_us.md
@@ -2177,6 +2177,18 @@ This brings back the classic behavior from Minecraft < 1.19.3
     - Minecraft (`minecraft`) `>=1.19.3`
 
 
+### tadpoleBucketGrowthLeftTime
+
+Display the growth left time of tadpole in first line of the tooltip of the tadpole bucket items
+
+- Category: MC Tweaks
+- Type: boolean (Generic)
+- Default value: `false`
+- Mod restrictions:
+  - Required mods:
+    - Minecraft (`minecraft`) `>=1.19`
+
+
 ### tickFreezeAutoReplaceWithUnfreeze
 
 When the game is frozen with the /tick freeze command, if you enter another /tick freeze 

--- a/docs/document-zh_cn.md
+++ b/docs/document-zh_cn.md
@@ -2171,6 +2171,18 @@ FOV覆盖的开关
     - Minecraft (`minecraft`) `>=1.19.3`
 
 
+### 蝌蚪桶中蝌蚪成长时间 (tadpoleBucketGrowthLeftTime)
+
+在蝌蚪桶物品工具提示的第一行显示其还有多久成长为青蛙
+
+- 分类: MC修改
+- 类型: 布尔值 (通用)
+- 默认值: `false`
+- 模组约束:
+  - 依赖模组:
+    - Minecraft (`minecraft`) `>=1.19`
+
+
 ### tickFreeze自动替换为unfreeze (tickFreezeAutoReplaceWithUnfreeze)
 
 当游戏被/tick freeze冻结后，若在聊天栏再次输入/tick freeze命令，

--- a/src/main/java/me/fallenbreath/tweakermore/config/TweakerMoreConfigs.java
+++ b/src/main/java/me/fallenbreath/tweakermore/config/TweakerMoreConfigs.java
@@ -708,6 +708,9 @@ public class TweakerMoreConfigs
 	@Config(type = Config.Type.GENERIC, restriction = @Restriction(conflict = @Condition(ModIds.locked_window_size)), category = Config.Category.MC_TWEAKS)
 	public static final TweakerMoreConfigBoolean WINDOW_SIZE_PINNED = newConfigBoolean("windowSizePinned", false);
 
+	@Config(type = Config.Type.GENERIC, restriction = @Restriction(require = @Condition(value = ModIds.minecraft, versionPredicates = ">=1.19")), category = Config.Category.MC_TWEAKS)
+	public static final TweakerMoreConfigBoolean TADPOLE_BUCKET_GROWTH_LEFT_TIME = newConfigBoolean("tadpoleBucketGrowthLeftTime", false);
+
 	////////////////////
 	//   Mod Tweaks   //
 	////////////////////

--- a/src/main/java/me/fallenbreath/tweakermore/impl/mc_tweaks/tadpoleBucketTooltipHints/TadpoleBucketToolTipEnhancer.java
+++ b/src/main/java/me/fallenbreath/tweakermore/impl/mc_tweaks/tadpoleBucketTooltipHints/TadpoleBucketToolTipEnhancer.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of the TweakerMore project, licensed under the
+ * GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2026  Fallen_Breath and contributors
+ *
+ * TweakerMore is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TweakerMore is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with TweakerMore.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.fallenbreath.tweakermore.impl.mc_tweaks.tadpoleBucketTooltipHints;
+
+public class TadpoleBucketToolTipEnhancer
+{
+	// impl in mc 1.19
+}

--- a/src/main/java/me/fallenbreath/tweakermore/mixins/tweaks/mc_tweaks/tadpoleBucketTooltipHints/ItemStackMixin.java
+++ b/src/main/java/me/fallenbreath/tweakermore/mixins/tweaks/mc_tweaks/tadpoleBucketTooltipHints/ItemStackMixin.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the TweakerMore project, licensed under the
+ * GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2023  Fallen_Breath and contributors
+ *
+ * TweakerMore is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TweakerMore is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with TweakerMore.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.fallenbreath.tweakermore.mixins.tweaks.mc_tweaks.tadpoleBucketTooltipHints;
+
+import me.fallenbreath.conditionalmixin.api.annotation.Condition;
+import me.fallenbreath.conditionalmixin.api.annotation.Restriction;
+import me.fallenbreath.tweakermore.util.ModIds;
+import me.fallenbreath.tweakermore.util.mixin.DummyClass;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Restriction(require = @Condition(value = ModIds.minecraft, versionPredicates = ">=1.19"))
+@Mixin(DummyClass.class)
+public abstract class ItemStackMixin
+{
+}

--- a/src/main/resources/assets/tweakermore/lang/en_us.yml
+++ b/src/main/resources/assets/tweakermore/lang/en_us.yml
@@ -837,6 +837,9 @@ tweakermore:
       comment: |-
         Make those players who don't have custom skins use only Steve or Alex as their default skins
         This brings back the classic behavior from Minecraft < 1.19.3
+    tadpoleBucketGrowthLeftTime:
+      .: tadpoleBucketGrowthLeftTime
+      comment: Display the growth left time of tadpole in first line of the tooltip of the tadpole bucket items
     tickFreezeAutoReplaceWithUnfreeze:
       .: tickFreezeAutoReplaceWithUnfreeze
       comment: |-

--- a/src/main/resources/assets/tweakermore/lang/zh_cn.yml
+++ b/src/main/resources/assets/tweakermore/lang/zh_cn.yml
@@ -836,6 +836,9 @@ tweakermore:
       comment: |-
         让那些没有自定义皮肤的玩家只使用Steve或Alex作为他们的默认皮肤
         这将带回Minecraft 1.19.3版本以前那个经典的只有Steve/Alex皮肤的世界
+    tadpoleBucketGrowthLeftTime:
+      .: 蝌蚪桶中蝌蚪成长时间
+      comment: 在蝌蚪桶物品工具提示的第一行显示其还有多久成长为青蛙
     tickFreezeAutoReplaceWithUnfreeze:
       .: tickFreeze自动替换为unfreeze
       comment: |-

--- a/src/main/resources/tweakermore.mixins.json
+++ b/src/main/resources/tweakermore.mixins.json
@@ -192,6 +192,7 @@
     "tweaks.mc_tweaks.spectatorTeleportMenuIncludeSpectator.TeleportSpectatorMenuMixin",
     "tweaks.mc_tweaks.spectatorTeleportMenuIncludeSpectator.TeleportToSpecificPlayerSpectatorCommandMixin",
     "tweaks.mc_tweaks.steveAlexOnlyDefaultSkins.DefaultSkinHelperMixin",
+    "tweaks.mc_tweaks.tadpoleBucketTooltipHints.ItemStackMixin",
     "tweaks.mc_tweaks.tickFreezeAutoReplaceWithUnfreeze.ClientPlayNetworkHandlerMixin",
     "tweaks.mc_tweaks.unlimitedBlockEntityRenderDistance.BlockEntityRenderDispatcherMixin",
     "tweaks.mc_tweaks.unlimitedEntityRenderDistance.EntityMixin",

--- a/versions/1.19.4/src/main/java/me/fallenbreath/tweakermore/impl/mc_tweaks/tadpoleBucketTooltipHints/TadpoleBucketToolTipEnhancer.java
+++ b/versions/1.19.4/src/main/java/me/fallenbreath/tweakermore/impl/mc_tweaks/tadpoleBucketTooltipHints/TadpoleBucketToolTipEnhancer.java
@@ -96,7 +96,7 @@ public class TadpoleBucketToolTipEnhancer
             //#endif
         int age = tag.getInt("Age")
             //#if MC >= 12105
-            //$$ .orElse(0);
+            //$$ .orElse(0)
             //#endif
             ;
         return Math.max(Tadpole.ticksToBeFrog - age, 0);

--- a/versions/1.19.4/src/main/java/me/fallenbreath/tweakermore/impl/mc_tweaks/tadpoleBucketTooltipHints/TadpoleBucketToolTipEnhancer.java
+++ b/versions/1.19.4/src/main/java/me/fallenbreath/tweakermore/impl/mc_tweaks/tadpoleBucketTooltipHints/TadpoleBucketToolTipEnhancer.java
@@ -41,72 +41,71 @@ import java.util.List;
 
 public class TadpoleBucketToolTipEnhancer
 {
+	public static void applyLeftTimeHint(ItemStack bucket, List<Component> tooltip)
+	{
+		if (!RenderGlobals.isOnRenderThread())
+		{
+			// Do nothing in case it's called from non-render thread by whatever mod
+			// see also: https://github.com/Fallen-Breath/tweakermore/issues/138
+			return;
+		}
+		if (!TweakerMoreConfigs.TADPOLE_BUCKET_GROWTH_LEFT_TIME.getBooleanValue())
+		{
+			return;
+		}
+		if (tooltip.isEmpty())
+		{
+			return;
+		}
 
-    public static void applyLeftTimeHint(ItemStack bucket, List<Component> tooltip)
-    {
-        if (!RenderGlobals.isOnRenderThread())
-        {
-            // Do nothing in case it's called from non-render thread by whatever mod
-            // see also: https://github.com/Fallen-Breath/tweakermore/issues/138
-            return;
-        }
-        if (!TweakerMoreConfigs.TADPOLE_BUCKET_GROWTH_LEFT_TIME.getBooleanValue())
-        {
-            return;
-        }
-        if (tooltip.isEmpty())
-        {
-            return;
-        }
+		int ticks = getTadpoleLeftTicks(bucket);
+		String time = formatTicksToMinuteSecond(ticks);
 
-        int ticks = getTadpoleLeftTicks(bucket);
-        String time = formatTicksToMinuteSecond(ticks);
+		Component timeText = Messenger.s(time, ChatFormatting.GRAY);
 
-        Component timeText = Messenger.s(time, ChatFormatting.GRAY);
+		// let timeText be rendered right-aligned
+		String spacing = " ";
+		Component firstLine = Messenger.c(tooltip.get(0), spacing, timeText);
+		Font textRenderer = Minecraft.getInstance().font;
 
-        // let timeText be rendered right-aligned
-        String spacing = " ";
-        Component firstLine = Messenger.c(tooltip.get(0), spacing, timeText);
-        Font textRenderer = Minecraft.getInstance().font;
+		int maxWidth = tooltip.stream().mapToInt(textRenderer::width).max().orElse(0);
 
-        int maxWidth = tooltip.stream().mapToInt(textRenderer::width).max().orElse(0);
+		while (true)
+		{
+			List<Component> siblings = firstLine.getSiblings();
+			spacing += " ";
+			Component prevSpacing = siblings.get(1);
+			siblings.set(1, Messenger.s(spacing));
+			if (textRenderer.width(firstLine) > maxWidth)
+			{
+				siblings.set(1, prevSpacing);  // rollback
+				break;
+			}
+		}
+		tooltip.set(0, firstLine);
+	}
 
-        while (true)
-        {
-            List<Component> siblings = firstLine.getSiblings();
-            spacing += " ";
-            Component prevSpacing = siblings.get(1);
-            siblings.set(1, Messenger.s(spacing));
-            if (textRenderer.width(firstLine) > maxWidth)
-            {
-                siblings.set(1, prevSpacing);  // rollback
-                break;
-            }
-        }
-        tooltip.set(0, firstLine);
-    }
+	private static int getTadpoleLeftTicks(ItemStack bucket)
+	{
+		CompoundTag tag =
+				//#if MC < 12006
+				bucket.getOrCreateTag();
+		//#else
+		//$$ bucket.getOrDefault(DataComponents.BUCKET_ENTITY_DATA, CustomData.EMPTY).copyTag();
+		//#endif
+		int age = tag.getInt("Age")
+				//#if MC >= 12105
+				//$$ .orElse(0)
+				//#endif
+				;
+		return Math.max(Tadpole.ticksToBeFrog - age, 0);
+	}
 
-    private static int getTadpoleLeftTicks(ItemStack bucket)
-    {
-        CompoundTag tag =
-            //#if MC < 12006
-            bucket.getOrCreateTag();
-            //#else
-            //$$ bucket.getOrDefault(DataComponents.BUCKET_ENTITY_DATA, CustomData.EMPTY).copyTag();
-            //#endif
-        int age = tag.getInt("Age")
-            //#if MC >= 12105
-            //$$ .orElse(0)
-            //#endif
-            ;
-        return Math.max(Tadpole.ticksToBeFrog - age, 0);
-    }
-
-    private static String formatTicksToMinuteSecond(int ticks)
-    {
-        int totalSeconds = Mth.ceil((double) ticks / 20);
-        int minutes = totalSeconds / 60;
-        int seconds = totalSeconds % 60;
-        return String.format("%d:%02d", minutes, seconds);
-    }
+	private static String formatTicksToMinuteSecond(int ticks)
+	{
+		int totalSeconds = Mth.ceil((double)ticks / 20);
+		int minutes = totalSeconds / 60;
+		int seconds = totalSeconds % 60;
+		return String.format("%d:%02d", minutes, seconds);
+	}
 }

--- a/versions/1.19.4/src/main/java/me/fallenbreath/tweakermore/impl/mc_tweaks/tadpoleBucketTooltipHints/TadpoleBucketToolTipEnhancer.java
+++ b/versions/1.19.4/src/main/java/me/fallenbreath/tweakermore/impl/mc_tweaks/tadpoleBucketTooltipHints/TadpoleBucketToolTipEnhancer.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of the TweakerMore project, licensed under the
+ * GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2023  Fallen_Breath and contributors
+ *
+ * TweakerMore is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TweakerMore is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with TweakerMore.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.fallenbreath.tweakermore.impl.mc_tweaks.tadpoleBucketTooltipHints;
+
+import me.fallenbreath.tweakermore.config.TweakerMoreConfigs;
+import me.fallenbreath.tweakermore.util.Messenger;
+import me.fallenbreath.tweakermore.util.render.context.RenderGlobals;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.animal.frog.Tadpole;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.List;
+
+//#if MC >= 12006
+//$$ import net.minecraft.core.component.DataComponents;
+//$$ import net.minecraft.world.item.component.CustomData;
+//#endif
+
+public class TadpoleBucketToolTipEnhancer
+{
+
+    public static void applyLeftTimeHint(ItemStack bucket, List<Component> tooltip)
+    {
+        if (!RenderGlobals.isOnRenderThread())
+        {
+            // Do nothing in case it's called from non-render thread by whatever mod
+            // see also: https://github.com/Fallen-Breath/tweakermore/issues/138
+            return;
+        }
+        if (!TweakerMoreConfigs.TADPOLE_BUCKET_GROWTH_LEFT_TIME.getBooleanValue())
+        {
+            return;
+        }
+        if (tooltip.isEmpty())
+        {
+            return;
+        }
+
+        int ticks = getTadpoleLeftTicks(bucket);
+        String time = formatTicksToMinuteSecond(ticks);
+
+        Component timeText = Messenger.s(time, ChatFormatting.GRAY);
+
+        // let timeText be rendered right-aligned
+        String spacing = " ";
+        Component firstLine = Messenger.c(tooltip.get(0), spacing, timeText);
+        Font textRenderer = Minecraft.getInstance().font;
+
+        int maxWidth = tooltip.stream().mapToInt(textRenderer::width).max().orElse(0);
+
+        while (true)
+        {
+            List<Component> siblings = firstLine.getSiblings();
+            spacing += " ";
+            Component prevSpacing = siblings.get(1);
+            siblings.set(1, Messenger.s(spacing));
+            if (textRenderer.width(firstLine) > maxWidth)
+            {
+                siblings.set(1, prevSpacing);  // rollback
+                break;
+            }
+        }
+        tooltip.set(0, firstLine);
+    }
+
+    private static int getTadpoleLeftTicks(ItemStack bucket)
+    {
+        CompoundTag tag =
+            //#if MC < 12006
+            bucket.getOrCreateTag();
+            //#else
+            //$$ bucket.getOrDefault(DataComponents.BUCKET_ENTITY_DATA, CustomData.EMPTY).copyTag();
+            //#endif
+        int age = tag.getInt("Age")
+            //#if MC >= 12105
+            //$$ .orElse(0);
+            //#endif
+            ;
+        return Math.max(Tadpole.ticksToBeFrog - age, 0);
+    }
+
+    private static String formatTicksToMinuteSecond(int ticks)
+    {
+        int totalSeconds = Mth.ceil((double) ticks / 20);
+        int minutes = totalSeconds / 60;
+        int seconds = totalSeconds % 60;
+        return String.format("%d:%02d", minutes, seconds);
+    }
+}

--- a/versions/1.19.4/src/main/java/me/fallenbreath/tweakermore/mixins/tweaks/mc_tweaks/tadpoleBucketTooltipHints/ItemStackMixin.java
+++ b/versions/1.19.4/src/main/java/me/fallenbreath/tweakermore/mixins/tweaks/mc_tweaks/tadpoleBucketTooltipHints/ItemStackMixin.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of the TweakerMore project, licensed under the
+ * GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2023  Fallen_Breath and contributors
+ *
+ * TweakerMore is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TweakerMore is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with TweakerMore.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.fallenbreath.tweakermore.mixins.tweaks.mc_tweaks.tadpoleBucketTooltipHints;
+
+import me.fallenbreath.conditionalmixin.api.annotation.Condition;
+import me.fallenbreath.conditionalmixin.api.annotation.Restriction;
+import me.fallenbreath.tweakermore.impl.mc_tweaks.tadpoleBucketTooltipHints.TadpoleBucketToolTipEnhancer;
+import me.fallenbreath.tweakermore.util.ModIds;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
+
+@Restriction(require = @Condition(value = ModIds.minecraft, versionPredicates = ">=1.19"))
+@Mixin(ItemStack.class)
+public abstract class ItemStackMixin
+{
+	@Inject(method = "getTooltipLines", at = @At("TAIL"))
+	private void shulkerTooltipFillLevelHint_doApply(CallbackInfoReturnable<List<Component>> cir)
+	{
+		ItemStack stack = (ItemStack) (Object) this;
+
+		if (stack.is(Items.TADPOLE_BUCKET))
+		{
+			TadpoleBucketToolTipEnhancer.applyLeftTimeHint(stack, cir.getReturnValue());
+		}
+	}
+}


### PR DESCRIPTION
- 添加了一个新的选项: 蝌蚪桶中蝌蚪成长时间`tadpoleBucketGrowthLeftTime`
  - 类似于`潜影盒物品填充率提示`在工具提示的第一行最后显示其还有多久成长为青蛙