### PR TITLE
Add Syncmatica_r material source to auto collector

### DIFF
--- a/docs/document-en_us.md
+++ b/docs/document-en_us.md
@@ -73,13 +73,29 @@ Items that will be thrown out from the container with autoCleanContainer
 
 ### autoCollectMaterialListItem
 
-Automatically collect missing items in litematica mod material list in the opened container to player inventory
+Automatically collect missing items from the selected material source in the opened container to player inventory
 
 and then close the container
 
 - Category: Features
 - Type: hotkey togglable boolean (Tweak)
 - Default value: *no hotkey*, `false`
+- Mod restrictions:
+  - Required mods:
+    - Litematica (`litematica`)
+    - Item Scroller (`itemscroller`)
+
+
+### Auto Collect Material List Item - Material Source (autoCollectMaterialListItemSource)
+
+The source of required materials used by autoCollectMaterialListItem
+
+Syncmatica_r reads the local player's claimed material requirements
+
+- Category: Features
+- Type: option list (List)
+- Default value: `Litematica`
+- Available options: `Litematica`, `Syncmatica_r`
 - Mod restrictions:
   - Required mods:
     - Litematica (`litematica`)

--- a/docs/document-zh_cn.md
+++ b/docs/document-zh_cn.md
@@ -73,13 +73,29 @@ TweakerMore提供的新功能
 
 ### 自动收集材料列表物品 (autoCollectMaterialListItem)
 
-打开容器后，自动收集litematica材料列表中缺失的物品至玩家物品栏
+打开容器后，根据所选材料来源自动收集缺失物品至玩家物品栏
 
 然后关闭容器
 
 - 分类: 功能
 - 类型: 带热键布尔值 (工具)
 - 默认值: *无快捷键*, `false`
+- 模组约束:
+  - 依赖模组:
+    - Litematica (`litematica`)
+    - Item Scroller (`itemscroller`)
+
+
+### 自动收集材料列表物品-材料来源 (autoCollectMaterialListItemSource)
+
+自动收集材料列表物品使用的所需材料来源
+
+Syncmatica_r来源会读取本地玩家已认领的材料需求
+
+- 分类: 功能
+- 类型: 选项列表 (列表)
+- 默认值: `Litematica`
+- 可用选项: `Litematica`, `Syncmatica_r`
 - 模组约束:
   - 依赖模组:
     - Litematica (`litematica`)

--- a/src/main/java/me/fallenbreath/tweakermore/config/TweakerMoreConfigs.java
+++ b/src/main/java/me/fallenbreath/tweakermore/config/TweakerMoreConfigs.java
@@ -120,6 +120,16 @@ public class TweakerMoreConfigs
 	public static final TweakerMoreConfigBooleanHotkeyed AUTO_COLLECT_MATERIAL_LIST_ITEM = newConfigBooleanHotkeyed("autoCollectMaterialListItem");
 
 	@Config(
+			type = Config.Type.LIST,
+			restriction = @Restriction(require = {
+					@Condition(ModIds.litematica),
+					@Condition(ModIds.itemscroller)
+			}),
+			category = Config.Category.FEATURES
+	)
+	public static final TweakerMoreConfigOptionList AUTO_COLLECT_MATERIAL_LIST_ITEM_SOURCE = newConfigOptionList("autoCollectMaterialListItemSource", AutoCollectMaterialListItemSource.DEFAULT);
+
+	@Config(
 			type = Config.Type.GENERIC,
 			restriction = @Restriction(require = {
 					@Condition(ModIds.litematica),

--- a/src/main/java/me/fallenbreath/tweakermore/config/options/listentries/AutoCollectMaterialListItemSource.java
+++ b/src/main/java/me/fallenbreath/tweakermore/config/options/listentries/AutoCollectMaterialListItemSource.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the TweakerMore project, licensed under the
+ * GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2026  Fallen_Breath and contributors
+ *
+ * TweakerMore is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TweakerMore is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with TweakerMore.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.fallenbreath.tweakermore.config.options.listentries;
+
+public enum AutoCollectMaterialListItemSource implements EnumOptionEntry
+{
+	LITEMATICA,
+	SYNCMATICA_R;
+
+	public static final AutoCollectMaterialListItemSource DEFAULT = LITEMATICA;
+
+	@Override
+	public EnumOptionEntry[] getAllValues()
+	{
+		return values();
+	}
+
+	@Override
+	public EnumOptionEntry getDefault()
+	{
+		return DEFAULT;
+	}
+
+	@Override
+	public String getTranslationPrefix()
+	{
+		return "tweakermore.list_entry.autoCollectMaterialListItemSource.";
+	}
+}

--- a/src/main/java/me/fallenbreath/tweakermore/impl/features/autoContainerProcess/processors/ContainerMaterialListItemCollector.java
+++ b/src/main/java/me/fallenbreath/tweakermore/impl/features/autoContainerProcess/processors/ContainerMaterialListItemCollector.java
@@ -35,8 +35,12 @@ import me.fallenbreath.tweakermore.TweakerMoreMod;
 import me.fallenbreath.tweakermore.config.TweakerMoreConfigs;
 import me.fallenbreath.tweakermore.config.options.TweakerMoreConfigBooleanHotkeyed;
 import me.fallenbreath.tweakermore.config.options.listentries.AutoCollectMaterialListItemLogType;
+import me.fallenbreath.tweakermore.config.options.listentries.AutoCollectMaterialListItemSource;
 import me.fallenbreath.tweakermore.mixins.tweaks.features.autoCollectMaterialListItem.MaterialListHudRendererAccessor;
 import me.fallenbreath.tweakermore.util.ItemUtils;
+import me.fallenbreath.tweakermore.util.RegistryUtils;
+import me.fallenbreath.tweakermore.util.compat.syncmatica.ClaimedMaterialRequirement;
+import me.fallenbreath.tweakermore.util.compat.syncmatica.SyncmaticaMaterialApiAccess;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.NonNullList;
@@ -44,6 +48,7 @@ import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.ChatFormatting;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -76,34 +81,44 @@ public class ContainerMaterialListItemCollector implements IContainerProcessor
 	@Override
 	public ProcessResult process(LocalPlayer player, AbstractContainerScreen<?> containerScreen, List<Slot> allSlots, List<Slot> playerInvSlots, List<Slot> containerInvSlots)
 	{
-		MaterialListBase materialList = DataManager.getMaterialList();
-		if (materialList == null)
+		List<MaterialRequirement> requirements;
+		MaterialListHudRendererAccessor hudRendererAccessor = null;
+		AutoCollectMaterialListItemSource source = (AutoCollectMaterialListItemSource)TweakerMoreConfigs.AUTO_COLLECT_MATERIAL_LIST_ITEM_SOURCE.getOptionListValue();
+		if (source == AutoCollectMaterialListItemSource.SYNCMATICA_R)
 		{
-			log(Message.MessageType.WARNING, "tweakermore.impl.autoCollectMaterialListItem.no_material_list");
-			return new ProcessResult(true, TweakerMoreConfigs.AUTO_COLLECT_MATERIAL_LIST_ITEM_CLOSE_GUI.getBooleanValue());
+			Optional<List<ClaimedMaterialRequirement>> claimedRequirements = SyncmaticaMaterialApiAccess.getClaimedMaterialRequirements(player.getUUID());
+			if (!claimedRequirements.isPresent())
+			{
+				log(Message.MessageType.WARNING, "tweakermore.impl.autoCollectMaterialListItem.syncmatica_r_unavailable");
+				return new ProcessResult(true, TweakerMoreConfigs.AUTO_COLLECT_MATERIAL_LIST_ITEM_CLOSE_GUI.getBooleanValue());
+			}
+			requirements = this.createSyncmaticaRequirements(claimedRequirements.get(), playerInvSlots, containerInvSlots);
+		}
+		else
+		{
+			MaterialListBase materialList = DataManager.getMaterialList();
+			if (materialList == null)
+			{
+				log(Message.MessageType.WARNING, "tweakermore.impl.autoCollectMaterialListItem.no_material_list");
+				return new ProcessResult(true, TweakerMoreConfigs.AUTO_COLLECT_MATERIAL_LIST_ITEM_CLOSE_GUI.getBooleanValue());
+			}
+
+			hudRendererAccessor = (MaterialListHudRendererAccessor)materialList.getHudRenderer();
+			// refresh before operation starts to make sure it's up-to-date
+			MaterialListUtils.updateAvailableCounts(materialList.getMaterialsAll(), player);
+			requirements = this.createLitematicaRequirements(materialList);
 		}
 
-		MaterialListHudRendererAccessor hudRendererAccessor = (MaterialListHudRendererAccessor)materialList.getHudRenderer();
 		String guiTitle = containerScreen.getTitle().getString();
-
-		// refresh before operation starts to make sure it's up-to-date
-		MaterialListUtils.updateAvailableCounts(materialList.getMaterialsAll(), player);
-		List<MaterialListEntry> missingOnly = materialList.getMaterialsMissingOnly(true);
 
 		boolean summaryOnly = TweakerMoreConfigs.AUTO_COLLECT_MATERIAL_LIST_ITEM_MESSAGE_TYPE.getOptionListValue() == AutoCollectMaterialListItemLogType.SUMMARY;
 		List<String> summaries = Lists.newArrayList();
 		boolean takenSomething = false;
 
-		for (MaterialListEntry entry : missingOnly)
+		for (MaterialRequirement requirement : requirements)
 		{
-			int materialListRequiredAmount = this.calculateMaterialListRequiredAmount(materialList, entry);
-			if (materialListRequiredAmount <= 0)
-			{
-				continue;
-			}
-
-			int collectionTarget = this.calculateCollectionTarget(entry.getStack(), materialListRequiredAmount);
-			MaterialCollection collection = this.createMaterialCollection(entry.getStack(), materialListRequiredAmount, collectionTarget, containerInvSlots);
+			int collectionTarget = this.calculateCollectionTarget(requirement.stack, requirement.requiredAmount);
+			MaterialCollection collection = this.createMaterialCollection(requirement.stack, requirement.requiredAmount, collectionTarget, containerInvSlots);
 			if (TweakerMoreConfigs.AUTO_COLLECT_MATERIAL_LIST_ITEM_REQUIRE_SUFFICIENT_SUPPLY.getBooleanValue() && !collection.hasSufficientSupply())
 			{
 				continue;
@@ -132,9 +147,101 @@ public class ContainerMaterialListItemCollector implements IContainerProcessor
 			log(Message.MessageType.INFO, Joiner.on(", ").join(summaries));
 		}
 
-		// refresh after operation ends
-		hudRendererAccessor.setLastUpdateTime(-1);
+		if (hudRendererAccessor != null)
+		{
+			// refresh after operation ends
+			hudRendererAccessor.setLastUpdateTime(-1);
+		}
 		return new ProcessResult(true, TweakerMoreConfigs.AUTO_COLLECT_MATERIAL_LIST_ITEM_CLOSE_GUI.getBooleanValue());
+	}
+
+	private List<MaterialRequirement> createLitematicaRequirements(MaterialListBase materialList)
+	{
+		List<MaterialRequirement> requirements = new ArrayList<>();
+		for (MaterialListEntry entry : materialList.getMaterialsMissingOnly(true))
+		{
+			int requiredAmount = this.calculateMaterialListRequiredAmount(materialList, entry);
+			if (requiredAmount > 0)
+			{
+				requirements.add(new MaterialRequirement(entry.getStack(), requiredAmount));
+			}
+		}
+		return requirements;
+	}
+
+	private List<MaterialRequirement> createSyncmaticaRequirements(List<ClaimedMaterialRequirement> claimedRequirements, List<Slot> playerInvSlots, List<Slot> containerInvSlots)
+	{
+		List<MaterialRequirement> requirements = new ArrayList<>();
+		for (ClaimedMaterialRequirement claimedRequirement : claimedRequirements)
+		{
+			if (!claimedRequirement.getVariant().isEmpty())
+			{
+				TweakerMoreMod.LOGGER.debug("Skipping unsupported Syncmatica_r material variant '{}' for {}", claimedRequirement.getVariant(), claimedRequirement.getItemId());
+				continue;
+			}
+
+			int requiredAmount = this.subtractPlayerInventory(claimedRequirement, playerInvSlots);
+			Optional<ItemStack> stack = this.findMatchingStack(claimedRequirement.getItemId(), containerInvSlots);
+			if (requiredAmount > 0 && stack.isPresent())
+			{
+				requirements.add(new MaterialRequirement(stack.get(), requiredAmount));
+			}
+		}
+		return requirements;
+	}
+
+	private int subtractPlayerInventory(ClaimedMaterialRequirement requirement, List<Slot> playerInvSlots)
+	{
+		long carriedAmount = 0;
+		for (Slot slot : playerInvSlots)
+		{
+			if (this.matchesItemId(slot.getItem(), requirement.getItemId()))
+			{
+				carriedAmount += slot.getItem().getCount();
+			}
+		}
+		return (int)Math.max(0, (long)requirement.getMissingAmount() - carriedAmount);
+	}
+
+	private Optional<ItemStack> findMatchingStack(String itemId, List<Slot> containerInvSlots)
+	{
+		for (Slot slot : containerInvSlots)
+		{
+			ItemStack stack = slot.getItem();
+			if (this.matchesItemId(stack, itemId))
+			{
+				return Optional.of(stack.copy());
+			}
+		}
+
+		if (TweakerMoreConfigs.AUTO_COLLECT_MATERIAL_LIST_ITEM_TAKE_SHULKER_BOXES.getBooleanValue())
+		{
+			for (Slot slot : containerInvSlots)
+			{
+				ItemStack containerStack = slot.getItem();
+				if (!ItemUtils.isShulkerBox(containerStack.getItem()))
+				{
+					continue;
+				}
+				Optional<NonNullList<ItemStack>> storedItems = me.fallenbreath.tweakermore.util.InventoryUtils.getStoredItems(containerStack);
+				if (storedItems.isPresent())
+				{
+					for (ItemStack storedStack : storedItems.get())
+					{
+						if (this.matchesItemId(storedStack, itemId))
+						{
+							return Optional.of(storedStack.copy());
+						}
+					}
+				}
+			}
+		}
+		return Optional.empty();
+	}
+
+	private boolean matchesItemId(ItemStack stack, String itemId)
+	{
+		return !stack.isEmpty() && RegistryUtils.getItemId(stack.getItem()).equals(itemId);
 	}
 
 	private int calculateMaterialListRequiredAmount(MaterialListBase materialList, MaterialListEntry entry)
@@ -295,7 +402,9 @@ public class ContainerMaterialListItemCollector implements IContainerProcessor
 			return "";
 		}
 
-		String formattedAmount = hudRendererAccessor.invokeGetFormattedCountString(amountRemaining, collection.stack.getMaxStackSize());
+		String formattedAmount = hudRendererAccessor != null ?
+				hudRendererAccessor.invokeGetFormattedCountString(amountRemaining, collection.stack.getMaxStackSize()) :
+				Integer.toString(amountRemaining);
 		return StringUtils.translate(translationKey, GuiBase.TXT_GOLD + formattedAmount + GuiBase.TXT_RST);
 	}
 
@@ -437,6 +546,18 @@ public class ContainerMaterialListItemCollector implements IContainerProcessor
 		{
 			this.slot = slot;
 			this.itemAmount = itemAmount;
+		}
+	}
+
+	private static class MaterialRequirement
+	{
+		private final ItemStack stack;
+		private final int requiredAmount;
+
+		private MaterialRequirement(ItemStack stack, int requiredAmount)
+		{
+			this.stack = stack;
+			this.requiredAmount = requiredAmount;
 		}
 	}
 

--- a/src/main/java/me/fallenbreath/tweakermore/util/ModIds.java
+++ b/src/main/java/me/fallenbreath/tweakermore/util/ModIds.java
@@ -62,6 +62,7 @@ public class ModIds
 	public static final String pistorder = "pistorder";
 	public static final String replay_mod = "replaymod";
 	public static final String sodium = "sodium";
+	public static final String syncmatica_r = "syncmatica_r";
 	public static final String xaero_betterpvp = "xaerobetterpvp";
 	public static final String xaero_minimap = "xaerominimap";
 	public static final String xaero_worldmap = "xaeroworldmap";

--- a/src/main/java/me/fallenbreath/tweakermore/util/compat/syncmatica/ClaimedMaterialRequirement.java
+++ b/src/main/java/me/fallenbreath/tweakermore/util/compat/syncmatica/ClaimedMaterialRequirement.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the TweakerMore project, licensed under the
+ * GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2026  Fallen_Breath and contributors
+ *
+ * TweakerMore is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TweakerMore is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with TweakerMore.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.fallenbreath.tweakermore.util.compat.syncmatica;
+
+public class ClaimedMaterialRequirement
+{
+	private final String itemId;
+	private final String variant;
+	private final int missingAmount;
+
+	public ClaimedMaterialRequirement(String itemId, String variant, int missingAmount)
+	{
+		this.itemId = itemId;
+		this.variant = variant;
+		this.missingAmount = missingAmount;
+	}
+
+	public String getItemId()
+	{
+		return this.itemId;
+	}
+
+	public String getVariant()
+	{
+		return this.variant;
+	}
+
+	public int getMissingAmount()
+	{
+		return this.missingAmount;
+	}
+}

--- a/src/main/java/me/fallenbreath/tweakermore/util/compat/syncmatica/SyncmaticaMaterialApiAccess.java
+++ b/src/main/java/me/fallenbreath/tweakermore/util/compat/syncmatica/SyncmaticaMaterialApiAccess.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of the TweakerMore project, licensed under the
+ * GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2026  Fallen_Breath and contributors
+ *
+ * TweakerMore is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TweakerMore is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with TweakerMore.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.fallenbreath.tweakermore.util.compat.syncmatica;
+
+import me.fallenbreath.tweakermore.TweakerMoreMod;
+import me.fallenbreath.tweakermore.util.FabricUtils;
+import me.fallenbreath.tweakermore.util.ModIds;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class SyncmaticaMaterialApiAccess
+{
+	private static final String API_CLASS_NAME = "cn.net.rms.syncmatica_r.api.SyncmaticaMaterialApi";
+
+	public static Optional<List<ClaimedMaterialRequirement>> getClaimedMaterialRequirements(UUID playerId)
+	{
+		if (!FabricUtils.isModLoaded(ModIds.syncmatica_r))
+		{
+			return Optional.empty();
+		}
+
+		try
+		{
+			Class<?> apiClass = Class.forName(API_CLASS_NAME);
+			Method apiMethod = apiClass.getMethod("getClaimedMaterialRequirements", UUID.class);
+			Object result = apiMethod.invoke(null, playerId);
+			return Optional.of(decodeRequirements(result));
+		}
+		catch (ReflectiveOperationException | RuntimeException e)
+		{
+			TweakerMoreMod.LOGGER.error("Failed to query Syncmatica_r material requirements", e);
+			return Optional.empty();
+		}
+	}
+
+	static List<ClaimedMaterialRequirement> decodeRequirements(Object result) throws ReflectiveOperationException
+	{
+		if (!(result instanceof List<?>))
+		{
+			throw new IllegalArgumentException("Syncmatica_r material API returned a non-list result");
+		}
+
+		List<ClaimedMaterialRequirement> requirements = new ArrayList<>();
+		for (Object entry : (List<?>)result)
+		{
+			Class<?> entryClass = entry.getClass();
+			String itemId = (String)entryClass.getMethod("itemId").invoke(entry);
+			String variant = (String)entryClass.getMethod("variant").invoke(entry);
+			int missingAmount = (Integer)entryClass.getMethod("missingAmount").invoke(entry);
+			requirements.add(new ClaimedMaterialRequirement(itemId, variant, missingAmount));
+		}
+		return requirements;
+	}
+}

--- a/src/main/resources/assets/tweakermore/lang/en_us.yml
+++ b/src/main/resources/assets/tweakermore/lang/en_us.yml
@@ -28,9 +28,15 @@ tweakermore:
     autoCollectMaterialListItem:
       .: autoCollectMaterialListItem
       comment: |-
-        Automatically collect missing items in litematica mod material list in the opened container to player inventory
+        Automatically collect missing items from the selected material source in the opened container to player inventory
         and then close the container
       pretty_name: Auto Collect Material List Item
+    autoCollectMaterialListItemSource:
+      .: Auto Collect Material List Item - Material Source
+      comment: |-
+        The source of required materials used by @option#autoCollectMaterialListItem@
+        Syncmatica_r reads the local player's claimed material requirements
+      pretty_name: Auto Collect Material List Item - Material Source
     autoCollectMaterialListItemCloseGui:
       .: autoCollectMaterialListItemCloseGui
       comment: If the container gui should be closed after using the @option#autoCollectMaterialListItem@ feature
@@ -1177,6 +1183,9 @@ tweakermore:
   # ================================ List entries ================================
 
   list_entry:
+    autoCollectMaterialListItemSource:
+      litematica: Litematica
+      syncmatica_r: Syncmatica_r
     autoCollectMaterialListItemMessageType:
       full: Full
       summary: Summary
@@ -1298,8 +1307,9 @@ tweakermore:
         material_list_remaining: ', still missing %1$s'
         over_required: ' (+%1$s over required)'
         target_remaining: ', %1$s short of collection target'
-      took_nothing: Took nothing required in the material list from %1$s
+      took_nothing: Took nothing required by the selected material source from %1$s
       no_material_list: No material list is activated
+      syncmatica_r_unavailable: Syncmatica_r material API is unavailable
     autoFillContainer:
       container_filled: Filled %1$s with all %2$s items (%3$s)
       best_slot_not_found: Most suitable item to fill the container not found

--- a/src/main/resources/assets/tweakermore/lang/zh_cn.yml
+++ b/src/main/resources/assets/tweakermore/lang/zh_cn.yml
@@ -28,9 +28,15 @@ tweakermore:
     autoCollectMaterialListItem:
       .: 自动收集材料列表物品
       comment: |-
-        打开容器后，自动收集litematica材料列表中缺失的物品至玩家物品栏
+        打开容器后，根据所选材料来源自动收集缺失物品至玩家物品栏
         然后关闭容器
       pretty_name: 自动收集材料列表物品
+    autoCollectMaterialListItemSource:
+      .: 自动收集材料列表物品-材料来源
+      comment: |-
+        @option#autoCollectMaterialListItem@使用的所需材料来源
+        Syncmatica_r来源会读取本地玩家已认领的材料需求
+      pretty_name: 自动收集材料列表物品-材料来源
     autoCollectMaterialListItemCloseGui:
       .: 自动收集材料列表物品-关闭GUI
       comment: 在使用@option#autoCollectMaterialListItem@功能后，是否关闭容器的GUI
@@ -1176,6 +1182,9 @@ tweakermore:
   # ================================ List entries ================================
 
   list_entry:
+    autoCollectMaterialListItemSource:
+      litematica: Litematica
+      syncmatica_r: Syncmatica_r
     autoCollectMaterialListItemMessageType:
       full: 完整
       summary: 摘要
@@ -1297,8 +1306,9 @@ tweakermore:
         material_list_remaining: '，仍需 %1$s'
         over_required: ' (比材料需求多拿 %1$s)'
         target_remaining: '，距拿取目标还差 %1$s'
-      took_nothing: 未在%1$s中收集任何材料列表中需要的物品
+      took_nothing: 未在%1$s中收集任何所选材料来源需要的物品
       no_material_list: 没有生效的材料列表
+      syncmatica_r_unavailable: Syncmatica_r材料API不可用
     autoFillContainer:
       container_filled: 已使用所有 %2$s 物品装填容器 %1$s (%3$s)
       best_slot_not_found: 未找到最适合装填容器的物品

--- a/src/test/java/me/fallenbreath/tweakermore/util/compat/syncmatica/SyncmaticaMaterialApiAccessTest.java
+++ b/src/test/java/me/fallenbreath/tweakermore/util/compat/syncmatica/SyncmaticaMaterialApiAccessTest.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of the TweakerMore project, licensed under the
+ * GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2026  Fallen_Breath and contributors
+ *
+ * TweakerMore is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TweakerMore is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with TweakerMore.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.fallenbreath.tweakermore.util.compat.syncmatica;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class SyncmaticaMaterialApiAccessTest
+{
+	@Test
+	public void decodesMaterialRequirementRecordShape() throws ReflectiveOperationException
+	{
+		List<ClaimedMaterialRequirement> requirements = SyncmaticaMaterialApiAccess.decodeRequirements(Arrays.asList(
+				new ApiRequirement("minecraft:stone", "", 64),
+				new ApiRequirement("minecraft:oak_planks", "future-variant", 12)
+		));
+
+		assertEquals(2, requirements.size());
+		assertEquals("minecraft:stone", requirements.get(0).getItemId());
+		assertEquals("", requirements.get(0).getVariant());
+		assertEquals(64, requirements.get(0).getMissingAmount());
+		assertEquals("minecraft:oak_planks", requirements.get(1).getItemId());
+		assertEquals("future-variant", requirements.get(1).getVariant());
+		assertEquals(12, requirements.get(1).getMissingAmount());
+	}
+
+	public static class ApiRequirement
+	{
+		private final String itemId;
+		private final String variant;
+		private final int missingAmount;
+
+		public ApiRequirement(String itemId, String variant, int missingAmount)
+		{
+			this.itemId = itemId;
+			this.variant = variant;
+			this.missingAmount = missingAmount;
+		}
+
+		public String itemId()
+		{
+			return this.itemId;
+		}
+
+		public String variant()
+		{
+			return this.variant;
+		}
+
+		public int missingAmount()
+		{
+			return this.missingAmount;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- add an `autoCollectMaterialListItemSource` option, defaulting to the existing Litematica source
- support claimed material requirements from Syncmatica_r's optional material API
- subtract the player's live inventory count exactly once before collecting
- preserve the existing extra amount, stack rounding, sufficient supply, retained item, and shulker box behavior
- add English and Chinese translations, generated documentation updates, and a reflection contract test

The compatibility layer uses reflection so Syncmatica_r remains optional and TweakerMore keeps building across all supported Minecraft mappings.

## Syncmatica_r

- Repository: https://github.com/Conflux-Union/syncmatica_r
- Material API contract: https://github.com/Conflux-Union/syncmatica_r/blob/for-rms/docs/MATERIAL_API.md

## Testing

Built and tested every exact Minecraft version currently shared by both projects:

- 1.17.1
- 1.20.1
- 1.21.1
- 1.21.4
- 1.21.8
- 1.21.10
- 1.21.11
- 26.2

```text
./gradlew :1.17.1:build :1.20.1:build :1.21.1:build :1.21.4:build :1.21.8:build :1.21.10:build :1.21.11:build :26.2:build
BUILD SUCCESSFUL
```